### PR TITLE
Update README with version 3.0 links and version 2.0 details

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Pipeline overview from [Pallast et al.](https://doi.org/10.3389/fninf.2019.00042
 
 ## Version history
 
-[Information latest Version 2.0](https://github.com/maswendt/AIDAmri/releases/tag/v2.0)
+[Information latest Version 3.0](Release_note.md)
 
+[Information about Version 2.0](https://github.com/maswendt/AIDAmri/releases/tag/v2.0)
+<br/>
 [Information about Version 1.2 (Docker stable release)](https://github.com/maswendt/AIDAmri/releases/tag/v1.2)
 <br/>
 [Information about Version 1.1.1 (Docker pre-release)](https://github.com/maswendt/AIDAmri/releases/tag/1.1.1)


### PR DESCRIPTION
This pull request updates the version history section in the `README.md` to reflect the latest release and improve clarity.

Version history updates:

* Updated the "latest version" link to point to Version 3.0 release notes in `Release_note.md`, and added a separate link for Version 2.0 information.