### PR TITLE
Enhance QC report generation and Docker compatibility for ARM

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -214,14 +214,17 @@ To start an AIDAmri container and make your data available inside it, run:
 
 ```text
 docker run -dit \
-  --name aidamri_container \
-  --mount type=bind,source=PATH/TO/DATA,target=/aida/DATA \
-  aidamri:latest
+    --platform linux/amd64 \
+    --name aidamri_container \
+    --mount type=bind,source=PATH/TO/DATA,target=/aida/DATA \
+    aidamri:latest
 ```
 
 The command performs the following function:
 `docker run` starts a new container from the AIDAmri Docker image.
 `-dit` starts the container in the background while keeping it interactive. This means the container keeps running, and you can enter it later.
+
+`--platform linux/amd64` explicitly selects the Linux AMD64 platform for which the image was built. This is particularly relevant on ARM-based hosts, such as Apple Silicon Macs or Windows-on-ARM devices, where Docker runs the image using AMD64 emulation. On standard Intel or AMD systems, this option is usually not required.
 
 `--name aidamri_container` gives the container a name. The container name is independent from the image name. In this example, the image is called `aidamri:latest`, while the container is called `aidamri_container`. If you wish to use more than one running container instance, for example to process multiple datasets simultaneously, each container needs a different name.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ If your problem is not listed here, please use our Gitter Chat or open an issue 
 
 
 ---
+<details>
+<summary><strong>Running Container Warning</strong></summary>
+ARM useres (e.g. Apple Silicon) may see the following warning when starting the conatiner:
+
+WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+
+The warning appears because the image was built for the AMD64 architecture, while the host uses ARM64. Docker can run the image using emulation, although performance may be reduced.
+It can be ignored and does not affect the functionality of the container.
+</details>
 
 <details>
 <summary><strong>General debugging tips</strong></summary>

--- a/bin/2.1_T2PreProcessing/preProcessing_T2.py
+++ b/bin/2.1_T2PreProcessing/preProcessing_T2.py
@@ -225,7 +225,8 @@ if __name__ == "__main__":
     horizontal_gradient = args.horizontal_gradient
     bias_method = args.bias_method
 
-    print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
+    if args.bet == "bet":
+        print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
 
     creat_brkraw_backup(input_file)
     header_check(input_file)

--- a/bin/2.2_DTIPreProcessing/preProcessing_DTI.py
+++ b/bin/2.2_DTIPreProcessing/preProcessing_DTI.py
@@ -369,8 +369,9 @@ if __name__ == "__main__":
     bias_method = args.bias_method
     output_path = os.path.dirname(input_file)
     b0_thresh=100
-
-    print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
+    
+    if args.bet == "bet":
+        print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
 
     creat_brkraw_backup(input_file)
     header_check(input_file)

--- a/bin/2.3_fMRIPreProcessing/preProcessing_fMRI.py
+++ b/bin/2.3_fMRIPreProcessing/preProcessing_fMRI.py
@@ -238,7 +238,8 @@ if __name__ == "__main__":
     bias_method = args.bias_method
     outputPath = os.path.dirname(inputFile)
 
-    print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
+    if args.bet == "bet":
+        print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
 
     create_brkraw_backup(inputFile)
     header_check(inputFile)

--- a/bin/4.1_T2mapPreProcessing/preProcessing_T2MAP.py
+++ b/bin/4.1_T2mapPreProcessing/preProcessing_T2MAP.py
@@ -207,7 +207,8 @@ if __name__ == "__main__":
     bias_method = args.bias_method
     output_path = os.path.dirname(input_file)
     
-    print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
+    if args.bet == "bet":
+        print(f"Frac: {frac} Radius: {radius} Gradient {horizontal_gradient}")
 
     create_brkraw_backup(input_file)
     header_check(input_file)

--- a/bin/batchProc.py
+++ b/bin/batchProc.py
@@ -481,7 +481,7 @@ def find(pattern, path):
     return result
 
 
-def create_qc_reports(project_path, steps):
+def create_qc_reports(project_path, steps, custom_parameters=None):
     requested_steps = set(steps)
 
     try:
@@ -498,7 +498,11 @@ def create_qc_reports(project_path, steps):
         try:
             print("Creating BET report...")
             logging.info("Creating BET report...")
-            html_path, count = build_bet_qc_report(project_path, n_slices=7)
+            html_path, count = build_bet_qc_report(
+                project_path,
+                n_slices=7,
+                custom_parameters=custom_parameters,
+            )
             if html_path:
                 print(f"BET report written to {html_path} ({count} image(s))")
                 logging.info("BET report written to %s (%s images)", html_path, count)
@@ -513,7 +517,11 @@ def create_qc_reports(project_path, steps):
         try:
             print("Creating Registration report...")
             logging.info("Creating Registration report...")
-            html_path, count = build_registration_qc_report(project_path, n_slices=7)
+            html_path, count = build_registration_qc_report(
+                project_path,
+                n_slices=7,
+                custom_parameters=custom_parameters,
+            )
             if html_path:
                 print(f"Registration report written to {html_path} ({count} image(s))")
                 logging.info("Registration report written to %s (%s images)", html_path, count)
@@ -532,6 +540,26 @@ def format_step_label(step):
         "process": "Processing",
     }
     return labels.get(step, step.capitalize())
+
+
+def get_explicit_cli_parameters(parser, args, argv):
+    """Return parsed values for options explicitly supplied on the command line."""
+    supplied_options = {value.split("=", 1)[0] for value in argv if value.startswith("-")}
+    parameters = []
+
+    for action in parser._actions:
+        if action.dest in {"help", "input"}:
+            continue
+        if not supplied_options.intersection(action.option_strings):
+            continue
+
+        long_option = next(
+            (option for option in action.option_strings if option.startswith("--")),
+            action.option_strings[0],
+        )
+        parameters.append((long_option, getattr(args, action.dest)))
+
+    return parameters
 
 
 TQDM_BAR_FORMAT = (
@@ -879,6 +907,9 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    import sys
+
+    custom_parameters = get_explicit_cli_parameters(parser, args, sys.argv[1:])
 
     pathToData = args.input
     sessions = args.sessions
@@ -1008,6 +1039,6 @@ if __name__ == "__main__":
                         # strings or unexpected types
                         print(f"Error: {err}")
 
-    create_qc_reports(pathToData, steps)
+    create_qc_reports(pathToData, steps, custom_parameters=custom_parameters)
 
  

--- a/bin/helper_tools/Readme.md
+++ b/bin/helper_tools/Readme.md
@@ -263,9 +263,22 @@ Available functions:
 ```python
 from batch_qc_reports import build_bet_qc_report, build_registration_qc_report
 
-build_bet_qc_report("/path/to/proc_data", n_slices=10)
-build_registration_qc_report("/path/to/proc_data", n_slices=10)
+build_bet_qc_report(
+    "/path/to/proc_data",
+    n_slices=10,
+    custom_parameters=[("--t2-frac", 0.1)],
+)
+build_registration_qc_report(
+    "/path/to/proc_data",
+    n_slices=10,
+    custom_parameters=[("--t2-frac", 0.1)],
+)
 ```
+
+When reports are created by `batchProc.py`, options explicitly supplied on the
+command line are listed in a **Custom parameters** section at the top of each
+HTML report. The required `--input` option is omitted. Direct callers can pass
+the optional `custom_parameters` sequence shown above.
 
 BET report behavior:
 

--- a/bin/helper_tools/batch_qc_reports.py
+++ b/bin/helper_tools/batch_qc_reports.py
@@ -194,7 +194,13 @@ def _plot_registration_overlay(bet_path, anno_path, out_dir, project_dir, n_slic
     return png_path, shape, anno_shape, zooms
 
 
-def _write_report(entries, out_dir, title, report_name):
+def _format_parameter_value(value):
+    if isinstance(value, (list, tuple)):
+        return " ".join(str(item) for item in value)
+    return str(value)
+
+
+def _write_report(entries, out_dir, title, report_name, custom_parameters=None):
     html_path = Path(out_dir) / report_name
     subjects = sorted({entry["subject"] for entry in entries})
     sessions = sorted({entry["session"] for entry in entries})
@@ -206,6 +212,11 @@ def _write_report(entries, out_dir, title, report_name):
             """
             <style>
             body { font-family: Arial, sans-serif; margin: 40px; }
+            .custom-parameters { background: #f3f6f8; border: 1px solid #ccd5db; border-radius: 4px; margin-bottom: 24px; padding: 16px 20px; }
+            .custom-parameters h2 { margin: 0 0 12px; }
+            .custom-parameters table { border-collapse: collapse; }
+            .custom-parameters th { padding: 3px 24px 3px 0; text-align: left; vertical-align: top; }
+            .custom-parameters td { padding: 3px 0; }
             .report-entry { margin-bottom: 40px; }
             .report-info { font-size: 1.0em; margin-bottom: 8px; line-height: 1.5; }
             .report-img { width: 100%; max-width: 1200px; border: 1px solid #ccc; }
@@ -244,6 +255,17 @@ def _write_report(entries, out_dir, title, report_name):
                 f.write(f"<option value='{escaped_value}'>{escaped_value}</option>")
             f.write("</select></label>\n")
         f.write("</div><div style='height:60px;'></div>\n")
+        if custom_parameters:
+            f.write("<section class='custom-parameters'>\n")
+            f.write("<h2>Custom parameters</h2>\n<table>\n")
+            for name, value in custom_parameters:
+                f.write(
+                    "<tr>"
+                    f"<th>{html.escape(str(name))}</th>"
+                    f"<td>{html.escape(_format_parameter_value(value))}</td>"
+                    "</tr>\n"
+                )
+            f.write("</table>\n</section>\n")
         f.write(f"<h1>{html.escape(title)}</h1>\n")
 
         for entry in entries:
@@ -266,7 +288,7 @@ def _write_report(entries, out_dir, title, report_name):
     return html_path
 
 
-def build_bet_qc_report(project_dir, n_slices=10):
+def build_bet_qc_report(project_dir, n_slices=10, custom_parameters=None):
     project_dir = Path(project_dir)
     out_dir = project_dir / "Report" / "BET"
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -301,11 +323,17 @@ def build_bet_qc_report(project_dir, n_slices=10):
 
     if not entries:
         return None, 0
-    html_path = _write_report(entries, out_dir, "BET Report", "bet_report.html")
+    html_path = _write_report(
+        entries,
+        out_dir,
+        "BET Report",
+        "bet_report.html",
+        custom_parameters=custom_parameters,
+    )
     return html_path, len(entries)
 
 
-def build_registration_qc_report(project_dir, n_slices=10):
+def build_registration_qc_report(project_dir, n_slices=10, custom_parameters=None):
     project_dir = Path(project_dir)
     out_dir = project_dir / "Report" / "Registration"
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -353,5 +381,6 @@ def build_registration_qc_report(project_dir, n_slices=10):
         out_dir,
         "Registration Report: BET + AnnoSplit_parental",
         "registration_report.html",
+        custom_parameters=custom_parameters,
     )
     return html_path, len(entries)


### PR DESCRIPTION
This pull request improves the documentation for running the AIDAmri Docker container, especially for users on ARM-based systems. It clarifies how to specify the correct platform when starting the container and adds a warning to help ARM users understand and handle architecture-related messages.

**Docker platform specification and ARM support:**

* Added the `--platform linux/amd64` flag to the example `docker run` command in `Manual.md` to ensure compatibility on ARM-based hosts (such as Apple Silicon Macs or Windows-on-ARM devices).
* Updated the explanation in `Manual.md` to describe the purpose of the `--platform linux/amd64` flag, emphasizing its relevance for ARM-based users and when it can be omitted.

**Documentation and user guidance:**

* Added a collapsible warning section to `README.md` that explains the architecture mismatch warning seen by ARM users, reassuring them that the warning is benign and does not impact container functionality.